### PR TITLE
fix: clear cookie on auth fail

### DIFF
--- a/server/auth/auth.handler.ts
+++ b/server/auth/auth.handler.ts
@@ -1,4 +1,8 @@
-import { FastifyInstance, FastifyRequest } from 'fastify';
+import {
+  FastifyInstance,
+  FastifyRequest,
+  FastifyReply
+} from 'fastify';
 import { NON_AUTH_ROUTES } from 'constants/non-auth-routes';
 import { verifyToken } from 'utils/jwt.utils';
 
@@ -71,7 +75,7 @@ async function verifyRoute(request: FastifyRequest) {
 //   throw new Error('Auth failed');
 // }
 
-async function jwtAuth(request: FastifyRequest) {
+async function jwtAuth(request: FastifyRequest, reply: FastifyReply) {
   if (request.cookies && request.cookies.token) {
     const token = request.cookies.token as string;
 
@@ -84,6 +88,7 @@ async function jwtAuth(request: FastifyRequest) {
       return;
     }
   }
+  reply.setCookie('token', '', { domain: '', maxAge: 0, httpOnly: true, secure: true, sameSite: 'none', path: '/', signed: false });
 
   throw new Error('Auth Failed');
 }

--- a/server/routes/auth/auth.route.ts
+++ b/server/routes/auth/auth.route.ts
@@ -30,7 +30,7 @@ const signIn: RouteOptions = {
     const userData = await controller.signInUserController(request.body as ValidateUser);
     if (userData?.token) {
       reply.setCookie('token', userData.token,
-        { signed: false, domain: '', path: '/', secure: false, httpOnly: true, maxAge: 86400, sameSite: 'none' });
+        { signed: false, domain: '', path: '/', secure: true, httpOnly: true, maxAge: 86400, sameSite: 'none' });
       reply.code(200).send({ message: 'User logged in successfully', user: userData.user });
       return;
     }


### PR DESCRIPTION
Cookie was not being properly cleared by setting response headers if auth failed

# Pull Request Template

## Description

Because of cookie not being cleared on auth fail, user was unable to sign in since old cookie was persisting in client side.

Fixes #92 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By creating and running scenarios where it used to break. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings